### PR TITLE
Fixed the pending TODO for last club category refactoring.

### DIFF
--- a/models.py
+++ b/models.py
@@ -13,6 +13,7 @@ from mtypes import (
     Audience,
     Bills_Status,
     BudgetType,
+    ClubBodyCategoryType,
     Event_Location,
     Event_Mode,
     Event_Status,
@@ -31,7 +32,7 @@ class Event(BaseModel):
     code: str | None = None
     clubid: str
     collabclubs: List[str] = []
-    studentBodyEvent: bool = False
+    club_category: ClubBodyCategoryType = ClubBodyCategoryType.club
 
     name: event_name_type
 
@@ -61,6 +62,7 @@ class Event(BaseModel):
     model_config = ConfigDict(
         populate_by_name=True,
         arbitrary_types_allowed=True,
+        str_strip_whitespace=True,
     )
 
 

--- a/mtypes.py
+++ b/mtypes.py
@@ -269,6 +269,11 @@ class BudgetType:
             raise ValueError("Amount must be positive")
         return value
 
+@strawberry.enum
+class ClubBodyCategoryType(StrEnum):
+    club = auto()
+    body = auto()
+    admin = auto()
 
 # for handling mongo ObjectIds
 class PyObjectId(ObjectId):

--- a/queries/events.py
+++ b/queries/events.py
@@ -285,7 +285,7 @@ def pendingEvents(clubid: str | None, info: Info) -> List[EventType]:
             requested_states |= {Event_State_Status.pending_room.value}
             searchspace["$or"] = [
                 {"status.budget": True},
-                {"studentBodyEvent": True},
+                {"club_category": "body"},
             ]
         if "club" == user["role"] and user["uid"] == clubid:
             requested_states |= {


### PR DESCRIPTION
Rather than just storing isStudentBodyEvent, save if it is club, body or admin and change progressEvent accordingly. 
Also, directly approve admin events.

Corresponding changes on the web need to be made. 
This be done once #52 and its web counterpart are checked and merged (as that also includes the usage of this variable)